### PR TITLE
feat: Add volume key shutter trigger

### DIFF
--- a/app/src/main/kotlin/com/hereliesaz/click/CameraTriggerHandler.kt
+++ b/app/src/main/kotlin/com/hereliesaz/click/CameraTriggerHandler.kt
@@ -151,4 +151,14 @@ class CameraTriggerHandler(
         }
         return false
     }
+
+    /**
+     * Processes a volume key event.
+     *
+     * @return `true` if a volume key event should trigger a picture, `false` otherwise.
+     */
+    fun handleVolumeKeyEvent(): Boolean {
+        val volumeKeyShutterEnabled = prefsProvider().getBoolean(MainActivity.KEY_VOLUME_KEY_SHUTTER_ENABLED, false)
+        return volumeKeyShutterEnabled
+    }
 }

--- a/app/src/main/kotlin/com/hereliesaz/click/ClickAccessibilityService.kt
+++ b/app/src/main/kotlin/com/hereliesaz/click/ClickAccessibilityService.kt
@@ -180,6 +180,20 @@ class ClickAccessibilityService : AccessibilityService(), SensorEventListener {
     /** Required by SensorEventListener, but not used here. */
     override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}
 
+    override fun onKeyEvent(event: android.view.KeyEvent): Boolean {
+        val keyCode = event.keyCode
+        if (event.action == android.view.KeyEvent.ACTION_DOWN &&
+            (keyCode == android.view.KeyEvent.KEYCODE_VOLUME_UP || keyCode == android.view.KeyEvent.KEYCODE_VOLUME_DOWN)) {
+            if (triggerHandler.handleVolumeKeyEvent()) {
+                takePicture()
+                // The event is handled, so prevent it from propagating further (e.g., changing the volume).
+                return true
+            }
+        }
+        // For all other keys, let the system handle them as usual.
+        return super.onKeyEvent(event)
+    }
+
     /**
      * Dispatches a tap gesture to take a picture.
      * If custom shutter coordinates are saved, it uses them. Otherwise, it defaults

--- a/app/src/main/kotlin/com/hereliesaz/click/MainActivity.kt
+++ b/app/src/main/kotlin/com/hereliesaz/click/MainActivity.kt
@@ -35,6 +35,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var backTapSwitch: SwitchMaterial
     private lateinit var vibrationSensitivitySeekbar: SeekBar
     private lateinit var themeSwitch: SwitchMaterial
+    private lateinit var volumeKeySwitch: SwitchMaterial
     private lateinit var prefs: SharedPreferences
 
     companion object {
@@ -53,6 +54,7 @@ class MainActivity : AppCompatActivity() {
         const val KEY_SHUTTER_X = "shutter_x"
         const val KEY_SHUTTER_Y = "shutter_y"
         const val KEY_BACK_TAP_SENSITIVITY = "back_tap_sensitivity"
+        const val KEY_VOLUME_KEY_SHUTTER_ENABLED = "volumeKeyShutterEnabled"
 
         /**
          * Checks if the specified Accessibility Service is currently enabled in the system settings.
@@ -96,6 +98,7 @@ class MainActivity : AppCompatActivity() {
         backTapSwitch = findViewById(R.id.back_tap_switch)
         vibrationSensitivitySeekbar = findViewById(R.id.vibration_sensitivity_seekbar)
         themeSwitch = findViewById(R.id.theme_switch)
+        volumeKeySwitch = findViewById(R.id.volume_key_switch)
 
 
         val enableServiceButton: Button = findViewById(R.id.enable_service_button)
@@ -166,6 +169,10 @@ class MainActivity : AppCompatActivity() {
         backTapSwitch.setOnCheckedChangeListener { _, isChecked ->
             prefs.edit().putBoolean(KEY_BACK_TAP_ENABLED, isChecked).apply()
         }
+
+        volumeKeySwitch.setOnCheckedChangeListener { _, isChecked ->
+            prefs.edit().putBoolean(KEY_VOLUME_KEY_SHUTTER_ENABLED, isChecked).apply()
+        }
     }
 
     /**
@@ -200,6 +207,7 @@ class MainActivity : AppCompatActivity() {
         backTapSwitch.isChecked = prefs.getBoolean(KEY_BACK_TAP_ENABLED, false)
         vibrationSensitivitySeekbar.progress = prefs.getInt(KEY_VIBRATION_SENSITIVITY, 50)
         vibrationSensitivitySeekbar.isEnabled = lensTapVibrationSwitch.isChecked
+        volumeKeySwitch.isChecked = prefs.getBoolean(KEY_VOLUME_KEY_SHUTTER_ENABLED, false)
     }
 
     /**

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -95,6 +95,16 @@
             android:paddingTop="12dp"
             android:paddingBottom="12dp"/>
 
+        <com.google.android.material.switchmaterial.SwitchMaterial
+            android:id="@+id/volume_key_switch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/enable_volume_key_shutter"
+            android:textAppearance="?attr/textAppearanceBodyLarge"
+            android:textColor="?attr/colorOnSurface"
+            android:paddingTop="12dp"
+            android:paddingBottom="12dp"/>
+
         <androidx.appcompat.widget.SwitchCompat
             android:id="@+id/lens_tap_proximity_switch"
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,4 +17,5 @@
     <string name="calibrate">Calibrate</string>
     <string name="calibrate_back_tap_title">Calibrate Back Tap</string>
     <string name="calibrate_back_tap_instructions">To calibrate, firmly tap the back of your phone three times. Use a normal tapping force.</string>
+    <string name="enable_volume_key_shutter">Enable Volume Key Shutter</string>
 </resources>

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -5,4 +5,4 @@
     android:accessibilityFeedbackType="feedbackGeneric"
     android:notificationTimeout="100"
     android:canRetrieveWindowContent="false"
-    android:accessibilityFlags="flagDefault" />
+    android:accessibilityFlags="flagDefault|flagRequestFilterKeyEvents" />

--- a/app/src/test/kotlin/com/hereliesaz/click/CameraTriggerHandlerTest.kt
+++ b/app/src/test/kotlin/com/hereliesaz/click/CameraTriggerHandlerTest.kt
@@ -94,4 +94,16 @@ class CameraTriggerHandlerTest {
         // A small change should not trigger it
         assertFalse(triggerHandler.handleAccelerometerEvent(x = 1f, y = 1f, z = 1f, lastX = 0f, lastY = 0f, lastZ = 0f))
     }
+
+    @Test
+    fun `handleVolumeKeyEvent returns true when enabled`() {
+        `when`(mockPrefs.getBoolean(MainActivity.KEY_VOLUME_KEY_SHUTTER_ENABLED, false)).thenReturn(true)
+        assertTrue(triggerHandler.handleVolumeKeyEvent())
+    }
+
+    @Test
+    fun `handleVolumeKeyEvent returns false when disabled`() {
+        `when`(mockPrefs.getBoolean(MainActivity.KEY_VOLUME_KEY_SHUTTER_ENABLED, false)).thenReturn(false)
+        assertFalse(triggerHandler.handleVolumeKeyEvent())
+    }
 }


### PR DESCRIPTION
This commit adds a new feature that allows users to trigger the camera shutter by pressing the volume keys.

- Adds a new switch in the main activity to enable/disable the feature.
- Modifies the accessibility service to listen for volume key events.
- Adds a new method to the camera trigger handler to process the event.
- Includes unit tests for the new logic.

## Summary by Sourcery

Enable triggering the camera shutter using volume buttons by adding a UI switch, handling key events in the accessibility service, updating its configuration, and covering the new logic with tests.

New Features:
- Support triggering the camera shutter via volume keys, controlled by a new switch in MainActivity.

Enhancements:
- Add handleVolumeKeyEvent in CameraTriggerHandler and override onKeyEvent in AccessibilityService with updated config to filter key events.

Tests:
- Add unit tests for handleVolumeKeyEvent behavior when the feature is enabled or disabled.